### PR TITLE
Add IPv6 DHT support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var K = 20
 var MAX_CONCURRENCY = 16
 var BOOTSTRAP_NODES = [
   {host: 'router.bittorrent.com', port: 6881},
-  {host: 'router.d.com', port: 6881},
+  {host: 'router.utorrent.com', port: 6881},
   {host: 'dht.transmissionbt.com', port: 6881}
 ]
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var equals = require('buffer-equals')
 var crypto = require('crypto')
 var events = require('events')
 var util = require('util')
-var Address6 = require('ip-address').Address6;
+var Address6 = require('ip-address').Address6
 
 var K = 20
 var MAX_CONCURRENCY = 1
@@ -97,13 +97,13 @@ RPC.prototype.response = function (node, query, response, nodes, cb) {
   }
 
   if (!response.id) response.id = this.id
-  var want = query.want;
+  var want = query.want
   if (!want) want = [this.ipv6 ? 'n6' : 'n4']
 
-  if (want.indexOf('n4') != -1) {
+  if (want.indexOf('n4') !== -1) {
     response.nodes = []
   }
-  if (want.indexOf('n6') != -1) {
+  if (want.indexOf('n6') !== -1) {
     response.nodes6 = []
   }
 
@@ -158,7 +158,7 @@ RPC.prototype.query = function (node, message, cb) {
   } else {
     if (!message.a) message.a = {}
     if (!message.a.id) message.a.id = this.id
-    if (!message.want) message.want = ['n6'];
+    if (!message.want) message.want = ['n6']
     if (node.token) message.a.token = node.token
     this.socket.query(node, message, cb)
   }
@@ -200,9 +200,9 @@ RPC.prototype._addNode = function (node) {
   if (!old) this.emit('node', node)
 }
 
-RPC.prototype.addNode = function(node) {
+RPC.prototype.addNode = function (node) {
   this.socket.checkHostProtocol(node.host)
-  this.nodes.add(node);
+  this.nodes.add(node)
 }
 
 RPC.prototype._closest = function (target, message, background, visit, cb) {
@@ -293,7 +293,7 @@ RPC.prototype._closest = function (target, message, background, visit, cb) {
       })
     }
 
-    var nodesResp = self.ipv6 ? r.nodes6 : r.nodes;
+    var nodesResp = self.ipv6 ? r.nodes6 : r.nodes
     var nodes = nodesResp ? self.parseNodes(nodesResp, self.ipv6) : []
     for (var i = 0; i < nodes.length; i++) add(nodes[i])
 
@@ -312,7 +312,7 @@ RPC.prototype._encodeIP = function (addr, buf, offset, ipv6) {
   return (ipv6 ? encodeipv6 : encodeipv4)(addr, buf, offset)
 }
 
-RPC.prototype._parseIP = function(buf, offset, ipv6) {
+RPC.prototype._parseIP = function (buf, offset, ipv6) {
   return (ipv6 ? parseIpv6 : parseIpv4)(buf, offset)
 }
 
@@ -320,15 +320,15 @@ function parseIpv4 (buf, offset) {
   return buf[offset++] + '.' + buf[offset++] + '.' + buf[offset++] + '.' + buf[offset++]
 }
 
-function parseIpv6(buf, offset) {
-  return Address6.fromByteArray(buf.slice(offset, offset + 16)).correctForm(); // Returns shortest possible form (e.g. '::1')
+function parseIpv6 (buf, offset) {
+  return Address6.fromByteArray(buf.slice(offset, offset + 16)).correctForm() // Returns shortest possible form (e.g. '::1')
 }
 
 RPC.prototype._encodeNodes = function (nodes) {
-  var base = 22; // 20 byte node id + 2 byte port
-  var size = base + (this.ipv6 ? 16 : 4); // 16 byte ipv6 address or 4 byte ipv4 address
+  var base = 22 // 20 byte node id + 2 byte port
+  var size = base + (this.ipv6 ? 16 : 4) // 16 byte ipv6 address or 4 byte ipv4 address
 
-  var buf = Buffer.alloc(nodes.length * size);
+  var buf = Buffer.alloc(nodes.length * size)
   var ptr = 0
 
   for (var i = 0; i < nodes.length; i++) {
@@ -338,7 +338,7 @@ RPC.prototype._encodeNodes = function (nodes) {
     node.id.copy(buf, ptr)
     ptr += 20
     var ip = (node.host || node.address)
-    ptr = this._encodeIP(ip, buf, ptr, this.ipv6);
+    ptr = this._encodeIP(ip, buf, ptr, this.ipv6)
     buf.writeUInt16BE(node.port, ptr)
     ptr += 2
   }
@@ -350,29 +350,29 @@ RPC.prototype._encodeNodes = function (nodes) {
 function encodeipv4 (addr, buf, offset) {
   var ip = addr.split('.')
   for (var j = 0; j < 4; j++) buf[offset++] = parseInt(ip[j] || 0, 10)
-  return offset;
+  return offset
 }
 
-function encodeipv6(addr, buf, offset) {
+function encodeipv6 (addr, buf, offset) {
   // Address6.toByteArray only creates as large of an array as necessary
   // Since the DHT protocol requires full-length IPv6 addresses, we padd
   // the buffer with enough zero bytes to make it 16 bytes long.
   try {
     var myAddr = new Address6(addr)
   } catch (err) {
-    err.message;
+    err.message
   }
   if (!myAddr.valid) {
-    throw new Error("Invalid address: " + addr)
+    throw new Error('Invalid address: ' + addr)
   }
-  var addrBuf = Buffer.from(myAddr.toByteArray());
-  if (addrBuf.length == 17) {
-    addrBuf = addrBuf.slice(1); // Work around bug in 'ip-address' where an extra leading zero is prepended
+  var addrBuf = Buffer.from(myAddr.toByteArray())
+  if (addrBuf.length === 17) {
+    addrBuf = addrBuf.slice(1) // Work around bug in 'ip-address' where an extra leading zero is prepended
   }
 
-  var finalBuf = Buffer.concat([Buffer.alloc(16 - addrBuf.length), addrBuf]);
-  finalBuf.copy(buf, offset);
-  return offset + 16;
+  var finalBuf = Buffer.concat([Buffer.alloc(16 - addrBuf.length), addrBuf])
+  finalBuf.copy(buf, offset)
+  return offset + 16
 }
 
 function toBootstrapArray (ipv6, val) {
@@ -380,36 +380,32 @@ function toBootstrapArray (ipv6, val) {
 
   var nodes = ipv6 ? BOOTSTRAP_NODES_IPV6 : BOOTSTRAP_NODES
   if (val === true) return nodes
-  return [].concat(val || nodes).map(function(p) { return parsePeer(p, ipv6) })
+  return [].concat(val || nodes).map(function (p) { return parsePeer(p, ipv6) })
 }
 
 function isNodeId (id) {
   return id && Buffer.isBuffer(id) && id.length === 20
 }
 
-RPC.prototype.parseNodes = function(buf, ipv6) {
+RPC.prototype.parseNodes = function (buf, ipv6) {
   var contacts = []
 
-  var base = 22; // 20 byte node id + 2 byte port
-  var step = base + (ipv6 ? 16 : 4); // 16 byte ipv6 address or 4 byte ipv4 address
+  var base = 22 // 20 byte node id + 2 byte port
+  var step = base + (ipv6 ? 16 : 4) // 16 byte ipv6 address or 4 byte ipv4 address
 
   for (var i = 0; i < buf.length; i += step) {
     var port = buf.readUInt16BE(i + (step - 2))
     if (!port) continue
     contacts.push({
-                    id: buf.slice(i, i + 20),
-                    host: this._parseIP(buf, i + 20, ipv6),
-                    port: port,
-                    distance: 0,
-                    token: null
-                  })
+      id: buf.slice(i, i + 20),
+      host: this._parseIP(buf, i + 20, ipv6),
+      port: port,
+      distance: 0,
+      token: null
+    })
   }
 
   return contacts
-}
-
-function parseNodeipv4(buf, offset) {
-  return buf.slice(offset)
 }
 
 function parsePeer (peer, ipv6) {

--- a/index.js
+++ b/index.js
@@ -285,7 +285,7 @@ RPC.prototype._closest = function (target, message, background, visit, cb) {
     }
 
     var nodesResp = self.ipv6 ? r.nodes6 : r.nodes;
-    var nodes = nodesResp ? parseNodes(nodesResp, self.ipv6) : []
+    var nodes = nodesResp ? self.parseNodes(nodesResp, self.ipv6) : []
     for (var i = 0; i < nodes.length; i++) add(nodes[i])
 
     if (visit && visit(res, peer) === false) stop = true
@@ -303,7 +303,7 @@ RPC.prototype._encodeIP = function (addr, buf, offset, ipv6) {
   return (ipv6 ? encodeipv6 : encodeipv4)(addr, buf, offset)
 }
 
-function _parseIP(buf, offset, ipv6) {
+RPC.prototype._parseIP = function(buf, offset, ipv6) {
   return (ipv6 ? parseIpv6 : parseIpv4)(buf, offset)
 }
 
@@ -348,7 +348,11 @@ function encodeipv6(addr, buf, offset) {
   // Address6.toByteArray only creates as large of an array as necessary
   // Since the DHT protocol requires full-length IPv6 addresses, we padd
   // the buffer with enough zero bytes to make it 16 bytes long.
-  var myAddr = new Address6(addr)
+  try {
+    var myAddr = new Address6(addr)
+  } catch (err) {
+    err.message;
+  }
   if (!myAddr.valid) {
     throw new Error("Blah")
   }
@@ -370,7 +374,7 @@ function isNodeId (id) {
   return id && Buffer.isBuffer(id) && id.length === 20
 }
 
-function parseNodes (buf, ipv6) {
+RPC.prototype.parseNodes = function(buf, ipv6) {
   var contacts = []
 
   var base = 22; // 20 byte node id + 2 byte port
@@ -381,7 +385,7 @@ function parseNodes (buf, ipv6) {
     if (!port) continue
     contacts.push({
                     id: buf.slice(i, i + 20),
-                    host: _parseIP(buf, i + 20, ipv6),
+                    host: this._parseIP(buf, i + 20, ipv6),
                     port: port,
                     distance: 0,
                     token: null

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var util = require('util')
 var Address6 = require('ip-address').Address6
 
 var K = 20
-var MAX_CONCURRENCY = 1
+var MAX_CONCURRENCY = 16
 var BOOTSTRAP_NODES = [
   {host: 'router.bittorrent.com', port: 6881},
   {host: 'router.d.com', port: 6881},

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "buffer-equals": "^1.0.3",
+    "ip-address": "^5.8.2",
     "k-bucket": "^3.0.1",
     "k-rpc-socket": "^1.5.0"
   },
@@ -13,7 +14,7 @@
     "tape": "^4.4.0"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "standard && node $NODE_DEBUG_OPTION test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tape": "^4.4.0"
   },
   "scripts": {
-    "test": "standard && node $NODE_DEBUG_OPTION test.js"
+    "test": "standard && node test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,17 +1,7 @@
 var krpc = require('./')
 var tape = require('tape')
 
-function localHost(ipv6, plainIpv6) {
-  if (ipv6) {
-    if (!plainIpv6) {
-      return '[::1]'
-    }
-    return '::1'
-  }
-  return '127.0.0.1'
-}
-
-function genericQuery (t, ipv6) {
+wrapTest(tape, 'query + reply', function (t, ipv6) {
   var server = krpc({ipv6: ipv6})
 
   server.on('query', function (query, peer) {
@@ -41,17 +31,9 @@ function genericQuery (t, ipv6) {
       t.same(message.r.hello, 42)
     }
   })
-}
-
-tape('ipv4 query + reply', function (t) {
-  genericQuery(t, false)
 })
 
-tape('ipv6 query + reply', function (t) {
-  genericQuery(t, true)
-})
-
-function genericClosest (t, ipv6) {
+wrapTest(tape, 'query + closest', function(t, ipv6) {
   var server = krpc({ipv6: ipv6})
   var other = krpc({ipv6: ipv6})
   var visitedOther = false
@@ -95,12 +77,27 @@ function genericClosest (t, ipv6) {
       }
     })
   })
+})
+
+function localHost(ipv6, plainIpv6) {
+  if (ipv6) {
+    if (!plainIpv6) {
+      return '[::1]'
+    }
+    return '::1'
+  }
+  return '127.0.0.1'
 }
 
-tape('ipv4 query + closest', function (t) {
-  genericClosest(t, false)
-})
+function wrapTest(test, str, func) {
+  test('ipv4 ' + str, function (t) {
+    func(t, false)
+    if (t._plan) {
+      t.plan(t._plan + 1)
+    }
 
-tape('ipv6 query + closest', function (t) {
-  genericClosest(t, true)
-})
+    t.test('ipv6 ' + str, function (newT) {
+      func(newT, true)
+    })
+  })
+}

--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ wrapTest(tape, 'query + reply', function (t, ipv6) {
   })
 })
 
-wrapTest(tape, 'query + closest', function(t, ipv6) {
+wrapTest(tape, 'query + closest', function (t, ipv6) {
   var server = krpc({ipv6: ipv6})
   var other = krpc({ipv6: ipv6})
   var visitedOther = false
@@ -79,7 +79,7 @@ wrapTest(tape, 'query + closest', function(t, ipv6) {
   })
 })
 
-function localHost(ipv6, plainIpv6) {
+function localHost (ipv6, plainIpv6) {
   if (ipv6) {
     if (!plainIpv6) {
       return '[::1]'
@@ -89,7 +89,7 @@ function localHost(ipv6, plainIpv6) {
   return '127.0.0.1'
 }
 
-function wrapTest(test, str, func) {
+function wrapTest (test, str, func) {
   test('ipv4 ' + str, function (t) {
     func(t, false)
     if (t._plan) {


### PR DESCRIPTION
[k-rpc-socket](https://github.com/mafintosh/k-rpc-socket/pull/6) | [k-rpc](https://github.com/mafintosh/k-rpc/pull/5) | [bittorrent-dht](https://github.com/feross/bittorrent-dht/pull/144) | [torrent-discovery](https://github.com/feross/torrent-discovery/pull/27) | [webtorrent](https://github.com/feross/webtorrent/pull/950)

This is one of many pull requests across the WebTorrent ecosystem to add IPv6 DHT support, as per https://github.com/feross/bittorrent-dht/issues/88

Per [the BEP 32 statement about maintaining distinct IPv4/IPv6 DHTs](http://www.bittorrent.org/beps/bep_0032.html#operation) and the discussion on https://github.com/feross/bittorrent-dht/issues/88, my implementation requires separate instances of `bittorrent-dht` and everything below it on the protocol stack (`k-rpc` and `k-rpc-socket`). `torrent-discovery ` maintains up to two `DHT` instances, one for each IP version used. Fortunately, WebTorrent already supports IPv6 peers, so no changes are needed in it beyond properly using the IPv6 DHT, if enabled in the options.

The best way to run all of my changes is by using the [npm link](https://docs.npmjs.com/cli/link) command. Assuming that all of the necessary modules (`k-rpc-socket`, `k-rpc`, `bittorrent-dht`, `torrent-discovery`, `webtorrent`, and `webtorrent-cli` are sibling directories, the following commands will set things up properly (starting from the parent directory):

```
cd k-rpc-socket
npm install
npm link
cd ../k-rpc
npm install
npm link k-rpc-socket
npm link
cd ../bittorrent-dht
npm install
npm link k-rpc
npm link
cd ../torrent-discovery
npm install
npm link bittorrent-dht
npm link
cd ../webtorrent
npm install
npm link bittorrent-dht
npm link torrent-discovery
npm link
cd ../webtorrent-cli
npm install
npm link webtorrent
```

From there, you can test and run individual modules as you choose.

---

**k-rpc** specific notes:

As this repository does more than `k-rpc-socket,` this PR is more involve than the [k-rpc-socket](https://github.com/mafintosh/k-rpc-socket/pull/6) pr. Like in `k-rpc-socket`, I add an `ipv6` parameter to control if a `k-rpc` instance is used for `IPv4` or `IPv6`. Most of the changes are for implementing the encoding/decoding of IPv6 nodes, as specified in [BEP 32](http://www.bittorrent.org/beps/bep_0032.html). As in `k-rpc`, I use a wrapper functions to run the tests with `IPv4` and `IPv6` rpc instances without duplicating code.

Notes:
* To handle the necessary parsing of IPv6 address (which is non-trivial), I've added the [ip-address](https://www.npmjs.com/package/ip-address) module. Apart from [a minor bug in getting the binary represntation of an address](https://github.com/beaugunderson/ip-address/issues/40), which I've fully worked around, it works well.

Caveats:
* [This line](https://github.com/mafintosh/k-rpc/compare/master...Aaron1011:ipv6?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR373) TODO could probably be made more efficient, but I didn't think that it was necessary.
* Unfortunately, I've only been able to find one public IPv6 DHT server (with a permanent domain name - there are of course many peers on the network) - the other two used as IPv4 DHT nodes don't even have AAAA DNS records. If anyone knows of any other IPv6 DHT bootstrap nodes, I'd be happy to add them.