### PR TITLE
fix timeout query peer address undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ RPC.prototype._closest = function (target, message, background, visit, cb) {
 
   function afterQuery (err, res, peer) {
     pending--
-    if (peer) queried[peer.address + ':' + peer.port] = true // need this for bootstrap nodes
+    if (peer) queried[(peer.address || peer.host) + ':' + peer.port] = true // need this for bootstrap nodes
 
     var r = res && res.r
     if (!r) return


### PR DESCRIPTION
if query timeout then the `peer.address` value in the `afterQuery` callback may be `undefined`,  but the `peer` object may have `host` property.

this fix can avoid duplicative query.

refer https://github.com/mafintosh/k-rpc-socket/blob/master/index.js#L192