### PR TITLE
Allow specifying custom implementation of k-rpc-socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Create a new rpc instance. Options include
   // how big should be routing buckets be. defaults to 20.
   k: 20,
   // the local node id. defaults to 20 random bytes
-  id: Buffer(...)
+  id: Buffer(...),
+  // optional k-rpc-socket instance
+  krpcSocket: krpcSocket(opts)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function RPC (opts) {
   var self = this
 
   this.id = toBuffer(opts.id || opts.nodeId || crypto.randomBytes(20))
-  this.socket = socket(opts)
+  this.socket = opts.krpcSocket || socket(opts)
   this.bootstrap = toBootstrapArray(opts.nodes || opts.bootstrap)
   this.concurrency = opts.concurrency || MAX_CONCURRENCY
   this.backgroundConcurrency = opts.backgroundConcurrency || (this.concurrency / 4) | 0


### PR DESCRIPTION
Just like k-rpc-socket [supports](https://github.com/mafintosh/k-rpc-socket/blob/master/index.js#L23) custom socket implementation to be specified as an option it would be nice to also support custom k-rpc-socket implementation.
I'm working on `webrtc-socket` and `k-rpc-socket-webrtc` and want to reuse `k-rpc` as is.