### PR TITLE
Use `randombytes` package in order to avoid large overhead of `crypto` in browserify build

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var socket = require('k-rpc-socket')
 var KBucket = require('k-bucket')
 var equals = require('buffer-equals')
-var crypto = require('crypto')
 var events = require('events')
+var randombytes = require('randombytes')
 var util = require('util')
 var Buffer = require('safe-buffer').Buffer
 
@@ -22,7 +22,7 @@ function RPC (opts) {
 
   var self = this
 
-  this.id = toBuffer(opts.id || opts.nodeId || crypto.randomBytes(20))
+  this.id = toBuffer(opts.id || opts.nodeId || randombytes(20))
   this.socket = socket(opts)
   this.bootstrap = toBootstrapArray(opts.nodes || opts.bootstrap)
   this.concurrency = opts.concurrency || MAX_CONCURRENCY

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "buffer-equals": "^1.0.3",
     "k-bucket": "^3.0.1",
     "k-rpc-socket": "^1.7.0",
-    "safe-buffer": "^5.1.1"
+    "safe-buffer": "^5.1.1",
+    "randombytes": "^2.0.5"
   },
   "devDependencies": {
     "standard": "*",


### PR DESCRIPTION
Before: 654 kB
After: 121 kB