### PR TITLE
Add support for ArrayBufferView (like Uint8Array) as node identifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,6 +350,7 @@ function noop () {}
 
 function toBuffer (str) {
   if (typeof str === 'string') return Buffer.from(str, 'hex')
+  if (ArrayBuffer.isView(str)) return Buffer.from(str.buffer, str.byteOffset, str.byteLength)
   if (Buffer.isBuffer(str)) return str
   throw new Error('Pass a buffer or a string')
 }


### PR DESCRIPTION
This makes my life a bit simpler when interacting with `bittorrent-dht` since `Uint8Array` is supported in browser natively and `Buffer` is not.

https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView