### PR TITLE
Use newer version of k-bucket

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "buffer-equals": "^1.0.3",
-    "k-bucket": "^3.3.0",
+    "k-bucket": "^4.0.0",
     "k-rpc-socket": "^1.7.2",
     "randombytes": "^2.0.5",
     "safe-buffer": "^5.1.1"


### PR DESCRIPTION
Newer version of faster and supports plain `Uint8Array` in addition to `Buffer`, see https://github.com/tristanls/k-bucket/pull/45
Together with #15 make my life much easier.