### PR TITLE
breaking, fix, perf: ESM, drop buffer, modernize

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Read [BEP 5](http://www.bittorrent.org/beps/bep_0005.html) and [BEP 44](http://w
 ## Usage
 
 ``` js
-var krpc = require('k-rpc')
-var rpc = krpc()
+import krpc from 'k-rpc'
+const rpc = new KRPC()
 
-var target = new Buffer('aaaabbbbccccddddeeeeffffaaaabbbbccccdddd', 'hex')
+const target = new Uint8Array(Buffer.from('aaaabbbbccccddddeeeeffffaaaabbbbccccdddd', 'hex'))
 
 // query the BitTorrent DHT to find nodes near the target buffer
 rpc.closest(target, {q: 'get_peers', a: {info_hash: target}}, onreply, done)
@@ -32,7 +32,7 @@ function done () {
 
 ## API
 
-#### `var rpc = krpc([options])`
+#### `const rpc = new KRPC([options])`
 
 Create a new rpc instance. Options include
 

--- a/example.js
+++ b/example.js
@@ -1,13 +1,13 @@
-var krpc = require('./')
-var rpc = krpc()
+import KRPC from './index.js'
+const rpc = new KRPC()
 
-var target = Buffer.from('aaaabbbbccccddddeeeeffffaaaabbbbccccdddd', 'hex')
+const target = Buffer.from('aaaabbbbccccddddeeeeffffaaaabbbbccccdddd', 'hex')
 
 rpc.on('query', function (query, peer) {
   // console.log(query, peer)
 })
 
-var then = Date.now()
+const then = Date.now()
 
 rpc.populate(rpc.id, { q: 'find_node', a: { id: rpc.id, target: rpc.id } }, function () {
   console.log('(populated)', Date.now() - then)
@@ -18,20 +18,21 @@ rpc.closest(target, { q: 'get_peers', a: { info_hash: target } }, visit, functio
 })
 
 function visit (res, peer) {
-  var peers = res.r.values ? parsePeers(res.r.values) : []
+  const peers = res.r.values ? parsePeers(res.r.values) : []
   if (peers.length) console.log('count peers:', peers.length)
 }
 
 function parsePeers (buf) {
-  var peers = []
+  const peers = []
 
   try {
-    for (var i = 0; i < buf.length; i++) {
-      var port = buf[i].readUInt16BE(4)
+    for (let i = 0; i < buf.length; i++) {
+      const view = new DataView(buf[i].buffer)
+      const port = view.getUint16(4)
       if (!port) continue
       peers.push({
         host: parseIp(buf[i], 0),
-        port: port
+        port
       })
     }
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -1,296 +1,292 @@
-var socket = require('k-rpc-socket')
-var KBucket = require('k-bucket')
-var events = require('events')
-var randombytes = require('randombytes')
-var util = require('util')
+import Socket from 'k-rpc-socket'
+import KBucket from 'k-bucket'
+import EventEmitter from 'events'
+import { hex2arr, randomBytes } from 'uint8-util'
 
-var K = 20
-var MAX_CONCURRENCY = 16
-var BOOTSTRAP_NODES = [
+const K = 20
+const MAX_CONCURRENCY = 16
+const BOOTSTRAP_NODES = [
   { host: 'router.bittorrent.com', port: 6881 },
   { host: 'router.utorrent.com', port: 6881 },
   { host: 'dht.transmissionbt.com', port: 6881 }
 ]
 
-module.exports = RPC
+export default class RPC extends EventEmitter {
+  constructor (opts) {
+    super()
+    if (!opts) opts = {}
 
-function RPC (opts) {
-  if (!(this instanceof RPC)) return new RPC(opts)
-  if (!opts) opts = {}
+    const self = this
 
-  var self = this
+    this._idLength = opts.idLength || 20
+    this.id = toBuffer(opts.id || opts.nodeId || randomBytes(this._idLength))
+    this.socket = opts.krpcSocket || new Socket(opts)
+    this.bootstrap = toBootstrapArray(opts.nodes || opts.bootstrap)
+    this.concurrency = opts.concurrency || MAX_CONCURRENCY
+    this.backgroundConcurrency = opts.backgroundConcurrency || (this.concurrency / 4) | 0
+    this.k = opts.k || K
+    this.destroyed = false
 
-  this._idLength = opts.idLength || 20
-  this.id = toBuffer(opts.id || opts.nodeId || randombytes(this._idLength))
-  this.socket = opts.krpcSocket || socket(opts)
-  this.bootstrap = toBootstrapArray(opts.nodes || opts.bootstrap)
-  this.concurrency = opts.concurrency || MAX_CONCURRENCY
-  this.backgroundConcurrency = opts.backgroundConcurrency || (this.concurrency / 4) | 0
-  this.k = opts.k || K
-  this.destroyed = false
+    this.pending = []
+    this.nodes = null
 
-  this.pending = []
-  this.nodes = null
+    this.socket.setMaxListeners(0)
+    this.socket.on('query', onquery)
+    this.socket.on('response', onresponse)
+    this.socket.on('warning', onwarning)
+    this.socket.on('error', onerror)
+    this.socket.on('update', onupdate)
+    this.socket.on('listening', onlistening)
 
-  this.socket.setMaxListeners(0)
-  this.socket.on('query', onquery)
-  this.socket.on('response', onresponse)
-  this.socket.on('warning', onwarning)
-  this.socket.on('error', onerror)
-  this.socket.on('update', onupdate)
-  this.socket.on('listening', onlistening)
+    this.clear()
 
-  events.EventEmitter.call(this)
-  this.clear()
-
-  function onupdate () {
-    while (self.pending.length && self.socket.inflight < self.concurrency) {
-      var next = self.pending.shift()
-      self.query(next[0], next[1], next[2])
-    }
-  }
-
-  function onerror (err) {
-    self.emit('error', err)
-  }
-
-  function onlistening () {
-    self.emit('listening')
-  }
-
-  function onwarning (err) {
-    self.emit('warning', err)
-  }
-
-  function onquery (query, peer) {
-    addNode(query.a, peer)
-    self.emit('query', query, peer)
-  }
-
-  function onresponse (reply, peer) {
-    addNode(reply.r, peer)
-  }
-
-  function addNode (data, peer) {
-    if (data && isNodeId(data.id, self._idLength) && !data.id.equals(self.id)) {
-      var old = self.nodes.get(data.id)
-      if (old) {
-        old.seen = Date.now()
-        return
+    function onupdate () {
+      while (self.pending.length && self.socket.inflight < self.concurrency) {
+        const next = self.pending.shift()
+        self.query(next[0], next[1], next[2])
       }
-      self._addNode({
-        id: data.id,
-        host: peer.address || peer.host,
-        port: peer.port,
-        distance: 0,
-        seen: Date.now()
-      })
+    }
+
+    function onerror (err) {
+      self.emit('error', err)
+    }
+
+    function onlistening () {
+      self.emit('listening')
+    }
+
+    function onwarning (err) {
+      self.emit('warning', err)
+    }
+
+    function onquery (query, peer) {
+      addNode(query.a, peer)
+      self.emit('query', query, peer)
+    }
+
+    function onresponse (reply, peer) {
+      addNode(reply.r, peer)
+    }
+
+    function addNode (data, peer) {
+      if (data && isNodeId(data.id, self._idLength) && !data.id.equals(self.id)) {
+        const old = self.nodes.get(data.id)
+        if (old) {
+          old.seen = Date.now()
+          return
+        }
+        self._addNode({
+          id: data.id,
+          host: peer.address || peer.host,
+          port: peer.port,
+          distance: 0,
+          seen: Date.now()
+        })
+      }
     }
   }
-}
 
-util.inherits(RPC, events.EventEmitter)
-
-RPC.prototype.response = function (node, query, response, nodes, cb) {
-  if (typeof nodes === 'function') {
-    cb = nodes
-    nodes = null
-  }
-
-  if (!response.id) response.id = this.id
-  if (nodes) response.nodes = encodeNodes(nodes, this._idLength)
-  this.socket.response(node, query, response, cb)
-}
-
-RPC.prototype.error = function (node, query, error, cb) {
-  this.socket.error(node, query, error, cb)
-}
-
-// bind([port], [address], [callback])
-RPC.prototype.bind = function () {
-  this.socket.bind.apply(this.socket, arguments)
-}
-
-RPC.prototype.address = function () {
-  return this.socket.address()
-}
-
-RPC.prototype.queryAll = function (nodes, message, visit, cb) {
-  if (!message.a) message.a = {}
-  if (!message.a.id) message.a.id = this.id
-
-  var stop = false
-  var missing = nodes.length
-  var hits = 0
-  var error = null
-
-  if (!missing) return cb(new Error('No nodes to query'), 0)
-
-  for (var i = 0; i < nodes.length; i++) {
-    this.query(nodes[i], message, done)
-  }
-
-  function done (err, res, peer) {
-    if (!err) hits++
-    else if (err.code >= 300 && err.code < 400) error = err
-    if (!err && !stop) {
-      if (visit && visit(res, peer) === false) stop = true
+  response (node, query, response, nodes, cb) {
+    if (typeof nodes === 'function') {
+      cb = nodes
+      nodes = null
     }
-    if (!--missing) cb(hits ? null : error || new Error('All queries failed'), hits)
-  }
-}
 
-RPC.prototype.query = function (node, message, cb) {
-  if (this.socket.inflight >= this.concurrency) {
-    this.pending.push([node, message, cb])
-  } else {
+    if (!response.id) response.id = this.id
+    if (nodes) response.nodes = encodeNodes(nodes, this._idLength)
+    this.socket.response(node, query, response, cb)
+  }
+
+  error (node, query, error, cb) {
+    this.socket.error(node, query, error, cb)
+  }
+
+  // bind([port], [address], [callback])
+  bind () {
+    this.socket.bind.apply(this.socket, arguments)
+  }
+
+  address () {
+    return this.socket.address()
+  }
+
+  queryAll (nodes, message, visit, cb) {
     if (!message.a) message.a = {}
     if (!message.a.id) message.a.id = this.id
-    if (node.token) message.a.token = node.token
-    this.socket.query(node, message, cb)
+
+    let stop = false
+    let missing = nodes.length
+    let hits = 0
+    let error = null
+
+    if (!missing) return cb(new Error('No nodes to query'), 0)
+
+    for (let i = 0; i < nodes.length; i++) {
+      this.query(nodes[i], message, done)
+    }
+
+    function done (err, res, peer) {
+      if (!err) hits++
+      else if (err.code >= 300 && err.code < 400) error = err
+      if (!err && !stop) {
+        if (visit && visit(res, peer) === false) stop = true
+      }
+      if (!--missing) cb(hits ? null : error || new Error('All queries failed'), hits)
+    }
   }
-}
 
-RPC.prototype.destroy = function (cb) {
-  this.destroyed = true
-  this.socket.destroy(cb)
-}
+  query (node, message, cb) {
+    if (this.socket.inflight >= this.concurrency) {
+      this.pending.push([node, message, cb])
+    } else {
+      if (!message.a) message.a = {}
+      if (!message.a.id) message.a.id = this.id
+      if (node.token) message.a.token = node.token
+      this.socket.query(node, message, cb)
+    }
+  }
 
-RPC.prototype.clear = function () {
-  var self = this
+  destroy (cb) {
+    this.destroyed = true
+    this.socket.destroy(cb)
+  }
 
-  this.nodes = new KBucket({
-    localNodeId: this.id,
-    numberOfNodesPerKBucket: this.k,
-    numberOfNodesToPing: this.concurrency
-  })
+  clear () {
+    const self = this
 
-  this.nodes.on('ping', onping)
-
-  function onping (older, newer) {
-    self.emit('ping', older, function swap (deadNode) {
-      if (!deadNode) return
-      if (deadNode.id) self.nodes.remove(deadNode.id)
-      self._addNode(newer)
+    this.nodes = new KBucket({
+      localNodeId: this.id,
+      numberOfNodesPerKBucket: this.k,
+      numberOfNodesToPing: this.concurrency
     })
-  }
-}
 
-RPC.prototype.populate = function (target, message, cb) {
-  this._closest(target, message, true, null, cb)
-}
+    this.nodes.on('ping', onping)
 
-RPC.prototype.closest = function (target, message, visit, cb) {
-  this._closest(target, message, false, visit, cb)
-}
-
-RPC.prototype._addNode = function (node) {
-  var old = this.nodes.get(node.id)
-  this.nodes.add(node)
-  if (!old) this.emit('node', node)
-}
-
-RPC.prototype._closest = function (target, message, background, visit, cb) {
-  if (!cb) cb = noop
-
-  var self = this
-  var count = 0
-  var queried = {}
-  var pending = 0
-  var once = true
-  var stop = false
-
-  if (!message.a) message.a = {}
-  if (!message.a.id) message.a.id = this.id
-
-  var table = new KBucket({
-    localNodeId: target,
-    numberOfNodesPerKBucket: this.k,
-    numberOfNodesToPing: this.concurrency
-  })
-
-  var evt = background ? 'postupdate' : 'update'
-  this.socket.on(evt, kick)
-  kick()
-
-  function kick () {
-    if (self.destroyed || self.socket.inflight >= self.concurrency) return
-
-    var otherInflight = self.pending.length + self.socket.inflight - pending
-    if (background && self.socket.inflight >= self.backgroundConcurrency && otherInflight) return
-
-    var closest = table.closest(target, self.k)
-    if (!closest.length || closest.length < self.bootstrap.length) {
-      closest = self.nodes.closest(target, self.k)
-      if (!closest.length || closest.length < self.bootstrap.length) bootstrap()
-    }
-
-    for (var i = 0; i < closest.length; i++) {
-      if (stop) break
-      if (self.socket.inflight >= self.concurrency) return
-
-      var peer = closest[i]
-      var id = peer.host + ':' + peer.port
-      if (queried[id]) continue
-      queried[id] = true
-
-      pending++
-      self.socket.query(peer, message, afterQuery)
-    }
-
-    if (!pending) {
-      self.socket.removeListener(evt, kick)
-      process.nextTick(done)
+    function onping (older, newer) {
+      self.emit('ping', older, function swap (deadNode) {
+        if (!deadNode) return
+        if (deadNode.id) self.nodes.remove(deadNode.id)
+        self._addNode(newer)
+      })
     }
   }
 
-  function done () {
-    cb(null, count)
+  populate (target, message, cb) {
+    this._closest(target, message, true, null, cb)
   }
 
-  function bootstrap () {
-    if (!once) return
-    once = false
-    self.bootstrap.forEach(function (peer) {
-      pending++
-      self.socket.query(peer, message, afterQuery)
+  closest (target, message, visit, cb) {
+    this._closest(target, message, false, visit, cb)
+  }
+
+  _addNode (node) {
+    const old = this.nodes.get(node.id)
+    this.nodes.add(node)
+    if (!old) this.emit('node', node)
+  }
+
+  _closest (target, message, background, visit, cb) {
+    if (!cb) cb = noop
+
+    const self = this
+    let count = 0
+    const queried = {}
+    let pending = 0
+    let once = true
+    let stop = false
+
+    if (!message.a) message.a = {}
+    if (!message.a.id) message.a.id = this.id
+
+    const table = new KBucket({
+      localNodeId: target,
+      numberOfNodesPerKBucket: this.k,
+      numberOfNodesToPing: this.concurrency
     })
-  }
 
-  function afterQuery (err, res, peer) {
-    pending--
-    if (peer) queried[(peer.address || peer.host) + ':' + peer.port] = true // need this for bootstrap nodes
+    const evt = background ? 'postupdate' : 'update'
+    this.socket.on(evt, kick)
+    kick()
 
-    if (peer && peer.id && self.nodes.get(peer.id)) {
-      if (err && (err.code === 'EUNEXPECTEDNODE' || err.code === 'ETIMEDOUT')) {
-        self.nodes.remove(peer.id)
+    function kick () {
+      if (self.destroyed || self.socket.inflight >= self.concurrency) return
+
+      const otherInflight = self.pending.length + self.socket.inflight - pending
+      if (background && self.socket.inflight >= self.backgroundConcurrency && otherInflight) return
+
+      let closest = table.closest(target, self.k)
+      if (!closest.length || closest.length < self.bootstrap.length) {
+        closest = self.nodes.closest(target, self.k)
+        if (!closest.length || closest.length < self.bootstrap.length) bootstrap()
+      }
+
+      for (let i = 0; i < closest.length; i++) {
+        if (stop) break
+        if (self.socket.inflight >= self.concurrency) return
+
+        const peer = closest[i]
+        const id = peer.host + ':' + peer.port
+        if (queried[id]) continue
+        queried[id] = true
+
+        pending++
+        self.socket.query(peer, message, afterQuery)
+      }
+
+      if (!pending) {
+        self.socket.removeListener(evt, kick)
+        process.nextTick(done)
       }
     }
 
-    var r = res && res.r
-    if (!r) return kick()
+    function done () {
+      cb(null, count)
+    }
 
-    if (!err && isNodeId(r.id, self._idLength)) {
-      count++
-      add({
-        id: r.id,
-        port: peer.port,
-        host: peer.host || peer.address,
-        distance: 0
+    function bootstrap () {
+      if (!once) return
+      once = false
+      self.bootstrap.forEach(function (peer) {
+        pending++
+        self.socket.query(peer, message, afterQuery)
       })
     }
 
-    var nodes = r.nodes ? parseNodes(r.nodes, self._idLength) : []
-    for (var i = 0; i < nodes.length; i++) add(nodes[i])
+    function afterQuery (err, res, peer) {
+      pending--
+      if (peer) queried[(peer.address || peer.host) + ':' + peer.port] = true // need this for bootstrap nodes
 
-    if (visit && visit(res, peer) === false) stop = true
+      if (peer && peer.id && self.nodes.get(peer.id)) {
+        if (err && (err.code === 'EUNEXPECTEDNODE' || err.code === 'ETIMEDOUT')) {
+          self.nodes.remove(peer.id)
+        }
+      }
 
-    kick()
-  }
+      const r = res && res.r
+      if (!r) return kick()
 
-  function add (node) {
-    if (node.id.equals(self.id)) return
-    table.add(node)
+      if (!err && isNodeId(r.id, self._idLength)) {
+        count++
+        add({
+          id: r.id,
+          port: peer.port,
+          host: peer.host || peer.address,
+          distance: 0
+        })
+      }
+
+      const nodes = r.nodes ? parseNodes(r.nodes, self._idLength) : []
+      for (let i = 0; i < nodes.length; i++) add(nodes[i])
+
+      if (visit && visit(res, peer) === false) stop = true
+
+      kick()
+    }
+
+    function add (node) {
+      if (node.id.equals(self.id)) return
+      table.add(node)
+    }
   }
 }
 
@@ -301,21 +297,22 @@ function toBootstrapArray (val) {
 }
 
 function isNodeId (id, idLength) {
-  return id && Buffer.isBuffer(id) && id.length === idLength
+  return id && ArrayBuffer.isView(id) && id.length === idLength
 }
 
 function encodeNodes (nodes, idLength) {
-  var buf = Buffer.allocUnsafe(nodes.length * (idLength + 6))
-  var ptr = 0
+  const buf = new Uint8Array(nodes.length * (idLength + 6))
+  const view = new DataView(buf.buffer)
+  let ptr = 0
 
-  for (var i = 0; i < nodes.length; i++) {
-    var node = nodes[i]
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]
     if (!isNodeId(node.id, idLength)) continue
     node.id.copy(buf, ptr)
     ptr += idLength
-    var ip = (node.host || node.address).split('.')
-    for (var j = 0; j < 4; j++) buf[ptr++] = parseInt(ip[j] || 0, 10)
-    buf.writeUInt16BE(node.port, ptr)
+    const ip = (node.host || node.address).split('.')
+    for (let j = 0; j < 4; j++) buf[ptr++] = parseInt(ip[j] || 0, 10)
+    view.setUint16(ptr, node.port)
     ptr += 2
   }
 
@@ -324,16 +321,17 @@ function encodeNodes (nodes, idLength) {
 }
 
 function parseNodes (buf, idLength) {
-  var contacts = []
+  const contacts = []
+  const view = new DataView(buf.buffer)
 
   try {
-    for (var i = 0; i < buf.length; i += (idLength + 6)) {
-      var port = buf.readUInt16BE(i + (idLength + 4))
+    for (let i = 0; i < buf.length; i += (idLength + 6)) {
+      const port = view.getUint16(i + (idLength + 4))
       if (!port) continue
       contacts.push({
         id: buf.slice(i, i + idLength),
         host: parseIp(buf, i + idLength),
-        port: port,
+        port,
         distance: 0,
         token: null
       })
@@ -357,8 +355,7 @@ function parsePeer (peer) {
 function noop () {}
 
 function toBuffer (str) {
-  if (Buffer.isBuffer(str)) return str
-  if (ArrayBuffer.isView(str)) return Buffer.from(str.buffer, str.byteOffset, str.byteLength)
-  if (typeof str === 'string') return Buffer.from(str, 'hex')
+  if (ArrayBuffer.isView(str)) return new Uint8Array(str.buffer, str.byteOffset, str.byteLength)
+  if (typeof str === 'string') return hex2arr(str)
   throw new Error('Pass a buffer or a string')
 }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,18 @@
   "name": "k-rpc",
   "version": "5.1.0",
   "description": "Low-level implementation of the k-rpc protocol used the BitTorrent DHT.",
-  "main": "index.js",
+  "type": "module",
+  "exports": {
+    "import": "./index.js"
+  },
   "dependencies": {
-    "k-bucket": "^5.0.0",
-    "k-rpc-socket": "^1.7.2",
-    "randombytes": "^2.0.5"
+    "k-bucket": "^5.1.0",
+    "k-rpc-socket": "^2.0.0",
+    "uint8-util": "^2.1.7"
   },
   "devDependencies": {
     "standard": "*",
-    "tape": "^4.4.0"
+    "tape": "^5.6.3"
   },
   "scripts": {
     "test": "standard && tape test.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k-rpc",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Low-level implementation of the k-rpc protocol used the BitTorrent DHT.",
   "type": "module",
   "exports": {

--- a/test.js
+++ b/test.js
@@ -1,18 +1,18 @@
-var krpc = require('./')
-var tape = require('tape')
+import KRPC from './index.js'
+import tape from 'tape'
 
 tape('query + reply', function (t) {
-  var server = krpc()
+  const server = new KRPC()
 
   server.on('query', function (query, peer) {
-    t.same(query.q.toString(), 'echo')
+    t.same(Buffer.from(query.q).toString(), 'echo')
     t.same(query.a.hello, 42)
     server.response(peer, query, { hello: 42 })
   })
 
   server.bind(0, function () {
-    var id = Buffer.from('aaaabbbbccccddddeeeeaaaabbbbccccddddeeee', 'hex')
-    var client = krpc({
+    const id = new Uint8Array(Buffer.from('aaaabbbbccccddddeeeeaaaabbbbccccddddeeee', 'hex'))
+    const client = new KRPC({
       nodes: ['localhost:' + server.address().port]
     })
 
@@ -33,28 +33,28 @@ tape('query + reply', function (t) {
 })
 
 tape('query + closest', function (t) {
-  var server = krpc()
-  var other = krpc()
-  var visitedOther = false
+  const server = new KRPC()
+  const other = new KRPC()
+  let visitedOther = false
 
   other.on('query', function (query, peer) {
     visitedOther = true
-    t.same(query.q.toString(), 'echo')
+    t.same(Buffer.from(query.q).toString(), 'echo')
     t.same(query.a.hello, 42)
     server.response(peer, query, { hello: 42 })
   })
 
   server.on('query', function (query, peer) {
-    t.same(query.q.toString(), 'echo')
+    t.same(Buffer.from(query.q).toString(), 'echo')
     t.same(query.a.hello, 42)
     server.response(peer, query, { hello: 42 }, [{ host: '127.0.0.1', port: other.address().port, id: other.id }])
   })
 
   other.bind(0, function () {
     server.bind(0, function () {
-      var replies = 2
-      var id = Buffer.from('aaaabbbbccccddddeeeeaaaabbbbccccddddeeee', 'hex')
-      var client = krpc({
+      let replies = 2
+      const id = new Uint8Array(Buffer.from('aaaabbbbccccddddeeeeaaaabbbbccccddddeeee', 'hex'))
+      const client = new KRPC({
         nodes: ['localhost:' + server.address().port, 'localhost:' + other.address().port]
       })
 


### PR DESCRIPTION
This PR modernizes this library, migrates to ESM, drops buffer and updates dependencies.

requires https://github.com/mafintosh/k-rpc-socket/pull/18 to be merged and released first

tests fail, but they failed before too, but they fail with the same exact values as before

closes:
- https://github.com/mafintosh/k-rpc/pull/18
- https://github.com/mafintosh/k-rpc/pull/3